### PR TITLE
fix(invoice): Add custom marshaling for Price

### DIFF
--- a/so24/invoice24/marshal.go
+++ b/so24/invoice24/marshal.go
@@ -1,0 +1,29 @@
+package invoice24
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+// NOTE: Custom marshaling for removing scientific notation from float64 Price
+func (i InvoiceRow) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type Alias InvoiceRow
+
+	modified := struct {
+		Alias
+		Price *string `xml:"Price,omitempty"` // Override the original field
+		// Fields that we're hiding from the original struct
+		OriginalPrice float64 `xml:"-"`
+	}{
+		Alias:         Alias(i),
+		OriginalPrice: i.Price, // Hide the original Price
+	}
+
+	// Only include Price if it's not zero
+	if i.Price != 0 {
+		formattedPrice := fmt.Sprintf("%.2f", i.Price)
+		modified.Price = &formattedPrice
+	}
+
+	return e.EncodeElement(modified, start)
+}

--- a/so24/invoice24/marshal_test.go
+++ b/so24/invoice24/marshal_test.go
@@ -1,0 +1,27 @@
+package invoice24
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshaledInvoiceRow(t *testing.T) {
+	assert := assert.New(t)
+	row := InvoiceRow{
+		Price: float64(1122062),
+	}
+
+	x, err := xml.Marshal(row)
+	assert.NoError(err)
+	assert.Equal("<InvoiceRow><Price>1122062.00</Price></InvoiceRow>", string(x))
+
+	row = InvoiceRow{
+		Price: float64(1337.37),
+	}
+
+	x, err = xml.Marshal(row)
+	assert.NoError(err)
+	assert.Equal("<InvoiceRow><Price>1337.37</Price></InvoiceRow>", string(x))
+}


### PR DESCRIPTION
If we don't have custom marshaler, we get the scientific notation, eg.
`1.122062e+06` for `1122062`.
